### PR TITLE
management service에서 queue subscribe 하고 있다가 욕설 검증하는 로직 추가

### DIFF
--- a/simple-board/community-service/config/initializers/rabbitmq.rb
+++ b/simple-board/community-service/config/initializers/rabbitmq.rb
@@ -3,7 +3,7 @@ require "bunny"
 module RabbitMQ
   class << self
     def connection
-      @connection ||= Bunny.new(host: "rabbitmq", port: 5672, username: "user", password: "password")
+      @connection ||= Bunny.new(host: "rabbitmq", port: 5672, username: "user", password: "password", automatically_recover: true)
     end
 
     def channel

--- a/simple-board/management-service/Gemfile
+++ b/simple-board/management-service/Gemfile
@@ -64,3 +64,4 @@ gem "pg", "~> 1.2" # Use PostgreSQL as the database for Active Record
 gem 'grpc'
 gem 'grpc-tools'
 gem 'google-protobuf'
+gem "bunny"

--- a/simple-board/management-service/app/protos/levenshtein_services_pb.rb
+++ b/simple-board/management-service/app/protos/levenshtein_services_pb.rb
@@ -4,7 +4,7 @@
 # levenshtein.proto
 
 require 'grpc'
-require 'levenshtein_pb'
+require_relative 'levenshtein_pb'
 
 module Levenshtein
   module LevenshteinService

--- a/simple-board/management-service/app/service/post_subscriber.rb
+++ b/simple-board/management-service/app/service/post_subscriber.rb
@@ -1,0 +1,46 @@
+require Rails.root.join("config", "initializers", "rabbitmq")
+require_relative "../protos/levenshtein_services_pb"
+
+class PostSubscriber
+  POST_QUEUE = "post".freeze
+
+  def subscribe(channel)
+    queue = channel.queue(POST_QUEUE, durable: true)
+
+    Rails.logger.info " [*] Waiting for messages in #{queue.name}. To exit press CTRL+C"
+
+    queue.subscribe do |delivery_info, properties, body|
+      Rails.logger.info "delivery_info: #{delivery_info}" + " / properties: #{properties}" + " / body: #{body}"
+      self.work(body)
+    end
+  end
+
+  private
+
+  def work(msg)
+    post_id = msg.to_i
+    post = Post.find(post_id)
+
+    # grpc 검증
+    detections = []
+    grpc_stub = Levenshtein::LevenshteinService::Stub.new('bad-word-detector-service:50051', :this_channel_is_insecure)
+    title_query = Levenshtein::Query.new(text: post.title)
+    content_query = Levenshtein::Query.new(text: post.content)
+    content_response = grpc_stub.search(content_query)
+    title_response = grpc_stub.search(title_query)
+
+    content_response.words.each do |word|
+      detections << { id: word.id, content: word.content, similarity_rate: word.similarity_rate }
+    end
+
+    title_response.words.each do |word|
+      detections << { id: word.id, content: word.content, similarity_rate: word.similarity_rate }
+    end
+
+    Rails.logger.info "[★] detections: #{detections.to_s}"
+
+    if (detections.length > 0)
+      post.update(is_visible: false)
+    end
+  end
+end

--- a/simple-board/management-service/config/initializers/rabbitmq.rb
+++ b/simple-board/management-service/config/initializers/rabbitmq.rb
@@ -1,0 +1,18 @@
+require "bunny"
+require_relative "../../app/service/post_subscriber"
+
+class RabbitMQ
+  def initialize
+    @connection ||= Bunny.new(host: "rabbitmq", port: 5672, username: "user", password: "password", automatically_recover: true)
+  end
+
+  def channel
+    @channel ||= @connection.start.create_channel
+  end
+end
+
+Thread.new do
+  rabbitmq = RabbitMQ.new
+  post_subscriber = PostSubscriber.new
+  post_subscriber.subscribe(rabbitmq.channel)
+end


### PR DESCRIPTION
## Related Issue

Related to : #26 

## Overview

- initializer에서 rabbit mq 로드하고 subscribe 실행하는 방식으로 구현
- 욕설 탐지율 조정이 필요할듯?

## Screenshot

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/f26fb734-7f26-47f7-b432-73fa7359517d" />